### PR TITLE
Aggiorna il target prima di disegnare

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -10,19 +10,12 @@ let board = require('./board');
 
 
 let targetBitmap;
-let targetTime = new Date(0);
 
 exports.findDiffPixel = function(callback) {
-	let currTime = new Date();
-	// update target each 30 mins
-	if (Math.floor((currTime - targetTime) / (1000 * 60)) >= 5) {
-		getTargetBitmap(function(bitmap) {
-			targetBitmap = bitmap;
-			findDiffPixel2(callback);
-		});
-	} else {
+	getTargetBitmap(function(bitmap) {
+		targetBitmap = bitmap;
 		findDiffPixel2(callback);
-	}
+	});	
 };
 
 function findDiffPixel2(callback) {


### PR DESCRIPTION
Ho cambiato `findDiffPixel` in modo che aggiorni il target prima di cercare i pixel diversi. Dovrebbe risolvere problemi come quello del pixel del cuore.  
L'ho testata e funziona, l'unica cosa è che se ci sono più di un account la funzione viene chiamata più spesso di 5 minuti, ma non penso sia così tanto overkill.
